### PR TITLE
feat: Allow templating in object keys

### DIFF
--- a/src/liquid_json.rs
+++ b/src/liquid_json.rs
@@ -54,6 +54,7 @@ mod tests {
     #[case(json!({"this":"{{ myval }}"}), json!({"myval": u32::MAX}), json!({"this":u32::MAX}))]
     // #[case(json!({"this":"{{ myval }}"}), json!({"myval": u64::MAX}), json!({"this":u64::MAX}))] // Fails for now...
     #[case(json!({"this":"{{ myval }}"}), json!({"myval": "5"}), json!({"this":"5"}))]
+    #[case(json!({"{{ myval }}":"bar"}), json!({"myval": "this"}), json!({"this":"bar"}))]
     #[case(json!({"this":"{{ myval }}"}), json!({"myval": 5.1}), json!({"this":5.1}))]
     #[case(json!({"this":"{{ myval }}"}), json!({"myval": [5.1,4.2]}), json!({"this":[5.1,4.2]}))]
     #[case(json!({"this":"{{ myval | each: \"my num: {{el}}\" | output}}"}), json!({"myval": [5.1,4.2]}), json!({"this":["my num: 5.1","my num: 4.2"]}))]


### PR DESCRIPTION
Add parsing of object keys as templates as well, allowing to use templating in keys, of course a template in key will get evaluated to a simple string.